### PR TITLE
use xfer3 instead of xfer2

### DIFF
--- a/pi5neo/pi5neo.py
+++ b/pi5neo/pi5neo.py
@@ -39,7 +39,7 @@ class Pi5Neo:
     def send_spi_data(self):
         """Send the raw data buffer to the NeoPixel strip via SPI"""
         spi_message = bytes(self.raw_data)
-        self.spi.xfer2(list(spi_message))
+        self.spi.xfer3(list(spi_message))
 
     def bitmask(self, byte, position):
         """Retrieve the value of a specific bit in a byte"""


### PR DESCRIPTION
`xref2` only allows hardcoded limit of 4096 for buffer size
xfer3 read bufsize from `/sys/module/spidev/parameters/bufsiz` instead of using hardcoded `4096` as mentioned above

References:
- https://github.com/doceme/py-spidev/pull/75
- https://github.com/doceme/py-spidev/issues/62

Alternatively, it could be dynamic, based on an option pased to constructor.