### PR TITLE
Refactor `update_strip` to support configurable delay.

### DIFF
--- a/examples/smooth_fade.py
+++ b/examples/smooth_fade.py
@@ -1,0 +1,20 @@
+# Smooth fade animation based on cosine
+from pi5neo import Pi5Neo
+import time
+from math import cos
+
+
+def smooth_fade(neo):
+    t = time.time()
+    for i in range(neo.num_leds):
+        intensity = int((cos(i * 0.01 + t) * 0.5 + 0.5) * 255)
+        neo.set_led_color(i, intensity, intensity, intensity)
+    neo.update_strip(sleep_duration=0.01)
+
+
+# Initialize Pi5Neo with 300 LEDs
+neo = Pi5Neo('/dev/spidev0.0', num_leds=300, spi_speed_khz=800)
+
+# Smooth fade effect
+while True:
+    smooth_fade(neo)

--- a/pi5neo/pi5neo.py
+++ b/pi5neo/pi5neo.py
@@ -76,8 +76,12 @@ class Pi5Neo:
             return True
         return False
 
-    def update_strip(self):
-        """Send the current state of the LED strip to the NeoPixels"""
+    def update_strip(self, sleep_duration=0.1):
+        """Send the current state of the LED strip to the NeoPixels
+         Parameters:
+        - sleep_duration (float): The duration (in seconds) to pause after sending the data.
+          If None, no delay is introduced.
+        """
         total_bytes = 0
         for i in range(self.num_leds):
             led = self.led_state[i]  # Get the color for each LED
@@ -86,4 +90,6 @@ class Pi5Neo:
                 self.raw_data[total_bytes] = bitstream[j]
                 total_bytes += 1
         self.send_spi_data()
-        time.sleep(0.1)  # Short delay to ensure data is sent
+
+        if sleep_duration is not None:
+            time.sleep(sleep_duration)


### PR DESCRIPTION
I have found that the hard wired delay prevents me from updating animations at a higher rate than 10Hz. I have added a configurable delay to `update_strip`, the `sleep_duration` parameter is in seconds and has a default value of `0.1` which is the same as the previously hard wired value.