### PR TITLE
Update GitHub Actions for publishing to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,34 +3,29 @@ name: Publish Python Package
 on:
   push:
     tags:
-      - 'v*.*.*'  # This workflow runs when pushing tags that match the versioning pattern, e.g., v1.0.0
+      - 'v*.*.*'
 
 jobs:
   publish-to-pypi:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine
+      - name: Install build tools
+        run: pip install --upgrade build twine
 
       - name: Build package
-        run: |
-          python setup.py sdist bdist_wheel
+        run: python -m build
 
       - name: Publish to PyPI
         env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          python -m twine upload dist/*
-
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: python -m twine upload dist/*


### PR DESCRIPTION
Updated workflow to use new versions of checkout and setup-python actions, and modified the publish step to use API token for authentication.